### PR TITLE
Bug 1668570 - Add experiment harness, and turn on/off urlbar engagement telemetry.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -6,11 +6,17 @@
 
 /* import-globals-from shim.js */
 
+const BRANCHES = {
+  CONTROL: "control",
+  TREATMENT: "treatment",
+};
+
 const URLBAR_PROVIDER_NAME = "pt-result";
 const DYNAMIC_TYPE_NAME = "dynamicPtResult";
 
 let api = browser.experiments.urlbar;
 let matchedResult = null;
+let testProvider = null;
 
 // Our provider.
 class ProviderDynamicPalmTree extends UrlbarProvider {
@@ -52,7 +58,82 @@ class ProviderDynamicPalmTree extends UrlbarProvider {
   }
 }
 
+/**
+ * Logs a debug message, which the test harness interprets as a message the
+ * add-on is sending to the test.  See head.js for info.
+ *
+ * @param {string} msg
+ *   The message.
+ */
+function sendTestMessage(msg) {
+  console.debug(browser.runtime.id, msg);
+}
+
+/**
+ * Resets all the state we set on enrollment in the study.
+ *
+ * @param {bool} isTreatmentBranch
+ *   True if we were enrolled on the treatment branch, false if control.
+ */
+async function unenroll(isTreatmentBranch) {
+  await browser.urlbar.engagementTelemetry.clear({});
+  if (isTreatmentBranch) {
+    testProvider.removeListeners();
+  }
+  sendTestMessage("unenrolled");
+}
+
+/**
+ * Sets up all appropriate state for enrollment in the study.
+ *
+ * @param {bool} isTreatmentBranch
+ *   True if we are enrolling on the treatment branch, false if control.
+ */
+async function enroll(isTreatmentBranch) {
+  await browser.normandyAddonStudy.onUnenroll.addListener(async () => {
+    await unenroll(isTreatmentBranch);
+  });
+
+  // Enable urlbar engagement event telemetry.  See bugs 1559136 and 1570683.
+  await browser.urlbar.engagementTelemetry.set({ value: true });
+
+  if (isTreatmentBranch) {
+    // Enable our provider.
+    testProvider = new ProviderDynamicPalmTree();
+  }
+
+  sendTestMessage("enrolled");
+}
+
 (async function main() {
-  let testProvider = new ProviderDynamicPalmTree();
-  addProvider(testProvider);
+  // As a development convenience, act like we're enrolled in the treatment
+  // branch if we're a temporary add-on.  onInstalled with details.temporary =
+  // true will be fired in that case.  Add the listener now before awaiting the
+  // study below to make sure we don't miss the event.
+  let installPromise = new Promise((resolve) => {
+    browser.runtime.onInstalled.addListener((details) => {
+      resolve(details.temporary);
+    });
+  });
+
+  // If we're enrolled in the study, set everything up, and then we're done.
+  let study = await browser.normandyAddonStudy.getStudy();
+  if (study) {
+    // Sanity check the study.  This conditional should always be true.
+    if (study.active && Object.values(BRANCHES).includes(study.branch)) {
+      await enroll(study.branch == BRANCHES.TREATMENT);
+    }
+    sendTestMessage("ready");
+    return;
+  }
+
+  // There's no study.  If installation happens, then continue with the
+  // development convenience described above.
+  installPromise.then(async (isTemporaryInstall) => {
+    if (isTemporaryInstall) {
+      console.debug("isTemporaryInstall");
+      await enroll(true);
+    }
+    sendTestMessage("ready");
+  });
 })();

--- a/src/experiments/urlbar/schema.json
+++ b/src/experiments/urlbar/schema.json
@@ -16,12 +16,6 @@
         }
       }
     ],
-    "properties": {
-      "engagementTelemetry": {
-        "$ref": "types.Setting",
-        "description": "Enables or disables the engagement telemetry for the current browser session."
-      }
-    },
     "events": [
       {
         "name": "onViewUpdateRequested",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
     }
   },
   "permissions": [
+    "normandyAddonStudy",
     "urlbar"
   ],
   "background": {


### PR DESCRIPTION
I'm not overly thrilled with the listener addition/removal mechanism here as it is quite a bit of copy/paste, but it was the overall simplest way I could think of whilst allowing the listeners to be removed.